### PR TITLE
allow SCSI medium removal after the restore process

### DIFF
--- a/pkg/usbms/ipod.go
+++ b/pkg/usbms/ipod.go
@@ -176,6 +176,14 @@ func (h *Host) IPodFinalize(reset bool) error {
 
 	if reset {
 		cbd = &CommandDataBuffer{
+			OperationCode: 0x1e,
+			Request: []byte{0, 0, 0, 0},
+		}
+		if err := h.RawCommand(cbd); err != nil {
+			return err
+		}
+
+		cbd = &CommandDataBuffer{
 			OperationCode: 0x1b,
 			Request:       []byte{0, 0, 0, 2},
 		}


### PR DESCRIPTION
in order to reboot the iPod post-restore, you have to first allow medium removal (SCSI `0x1e`) before stopping it (SCSI `0x1b`). after a firmware payload is sent, this reliably restarts the iPod. I haven't been able to reboot the iPod post-upgrade without it.

tested on n3g.