### PR TITLE
pkg/exploit: add NANDIdentify method

### DIFF
--- a/cmd/wInd3x/main.go
+++ b/cmd/wInd3x/main.go
@@ -44,6 +44,7 @@ func main() {
 	rootCmd.AddCommand(dumpCmd)
 	rootCmd.AddCommand(decryptCmd)
 	nandCmd.AddCommand(nandReadCmd)
+	nandCmd.AddCommand(nandIdentifyCmd)
 	rootCmd.AddCommand(nandCmd)
 	norCmd.AddCommand(norReadCmd)
 	rootCmd.AddCommand(norCmd)

--- a/pkg/exploit/exploit.go
+++ b/pkg/exploit/exploit.go
@@ -36,6 +36,8 @@ type Parameters interface {
 
 	NANDInit(bank uint32) ([]uasm.Statement, error)
 	NANDReadPage(bank, page, offset uint32) ([]uasm.Statement, uint32)
+	// Read JEDEC identifer from currently selected bank
+	NANDIdentify() ([]uasm.Statement, uint32)
 
 	NORInit(spino uint32) ([]uasm.Statement, error)
 	NORRead(spino uint32, offset uint32) ([]uasm.Statement, uint32)

--- a/pkg/exploit/s5late_n7g.go
+++ b/pkg/exploit/s5late_n7g.go
@@ -75,6 +75,10 @@ func (p *S5LateParameters) NANDReadPage(bank, page, offset uint32) ([]uasm.State
 	panic("unimplemented")
 }
 
+func (p *S5LateParameters) NANDIdentify() ([]uasm.Statement, uint32) {
+	panic("unimplemented")
+}
+
 func (p *S5LateParameters) NORInit(spino uint32) ([]uasm.Statement, error) {
 	return nil, fmt.Errorf("unimplemented")
 }

--- a/pkg/exploit/wind3x_n3g.go
+++ b/pkg/exploit/wind3x_n3g.go
@@ -7,6 +7,31 @@ import (
 	"github.com/freemyipod/wInd3x/pkg/uasm"
 )
 
+// Flash Management Controller
+const (
+	// Base Address for the first controller
+	FMC_BASE0 = 0x38a00000
+
+	// Control Register 0
+	FMC_CTRL0_OFF = 0x00
+	// Control Register 1
+	FMC_CTRL1_OFF = 0x04
+	// Command Register
+	FMC_CMD_OFF = 0x08
+	// Address Register
+	FMC_ADDR0_OFF = 0x0c
+	FMC_ADDR1_OFF = 0x10
+	FMC_ADDR2_OFF = 0x14
+	// Address Counter Register
+	FMC_ANUM_OFF = 0x2c
+	// Data Counter Register
+	FMC_DNUM_OFF = 0x30
+	// Status Register
+	FMC_STAT_OFF = 0x48
+	// FIFO Start
+	FMC_FIFO_OFF = 0x80
+)
+
 type epNano3G struct{}
 
 func (_ *epNano3G) Prepare(_ devices.Usb) error {
@@ -164,6 +189,75 @@ func (_ *epNano3G) NANDInit(bank uint32) ([]uasm.Statement, error) {
 func (_ *epNano3G) NANDReadPage(bank, page, offset uint32) ([]uasm.Statement, uint32) {
 	// Call with bogus last argument (needs 12 bytes of data output as extra argument... ECC..?)
 	return makeCall(0x20009910, 0, bank, page, 0x22000100, 0x22000000), 0x22000100 + offset
+}
+
+func (_ *epNano3G) NANDIdentify() ([]uasm.Statement, uint32) {
+	return []uasm.Statement{
+		uasm.Ldr{Dest: uasm.R0, Src: uasm.Constant(FMC_BASE0)},  // Address base of first FMC controller
+		uasm.Ldr{Dest: uasm.R2, Src: uasm.Constant(0x22000100)}, // Destination buffer
+
+		// Write Read Command 0x90 to FMCMD
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(0x90)}, // Read ID Command
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_CMD_OFF)},
+
+		uasm.Label("wait_rbb_done_loop"),
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Deref(uasm.R0, FMC_STAT_OFF)},
+		uasm.And{Dest: uasm.R1, Src: uasm.R1, Compl: uasm.Immediate(0x2)}, // RBB_DONE
+		uasm.Cmp{A: uasm.R1, B: uasm.Immediate(0x2)},
+		uasm.B{Cond: uasm.NE, Dest: uasm.LabelRef("wait_rbb_done_loop")},
+
+		// Set rbb done
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(0x2)},
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_STAT_OFF)},
+
+		// Read from address 0x00 to get the identifier
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(0x00)},
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_ANUM_OFF)},
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_ADDR0_OFF)},
+
+		// Transfer the address
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(0x1)}, // Set DO_TRANS_ADDR bit
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_CTRL1_OFF)},
+
+		uasm.Label("wait_cmd_done_loop"),
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Deref(uasm.R0, FMC_STAT_OFF)},
+		uasm.And{Dest: uasm.R1, Src: uasm.R1, Compl: uasm.Immediate(0x4)}, // CMD_DONE
+		uasm.Cmp{A: uasm.R1, B: uasm.Immediate(0x4)},
+		uasm.B{Cond: uasm.NE, Dest: uasm.LabelRef("wait_cmd_done_loop")},
+
+		// Set cmd done
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(0x4)},
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_STAT_OFF)},
+
+		// We want to read seven bytes of data
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(7)},
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_DNUM_OFF)},
+
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(1)},
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_ADDR2_OFF)}, // IDK was in CS code
+
+		// Read the data
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(0x000001C2)}, // DO_READ_DATA, Flush FIFOs
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_CTRL1_OFF)},
+
+		// Wait for transfer to complete
+		uasm.Label("wait_addr_done_loop"),
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Deref(uasm.R0, FMC_STAT_OFF)},
+		uasm.And{Dest: uasm.R1, Src: uasm.R1, Compl: uasm.Immediate(0x8)}, // ADDR_DONE
+		uasm.Cmp{A: uasm.R1, B: uasm.Immediate(0x8)},
+		uasm.B{Cond: uasm.NE, Dest: uasm.LabelRef("wait_addr_done_loop")},
+
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(0x00000100)},
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_ADDR2_OFF)}, // IDK was in CS code
+
+		// Flush WFIFO and Parity
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Constant(0x00000340)},
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R0, FMC_CTRL1_OFF)},
+
+		// Copy to destination buffer
+		uasm.Ldr{Dest: uasm.R1, Src: uasm.Deref(uasm.R0, FMC_FIFO_OFF)},
+		uasm.Str{Src: uasm.R1, Dest: uasm.Deref(uasm.R2, 0)},
+	}, 0x22000100
 }
 
 func (_ *epNano3G) NORInit(spino uint32) ([]uasm.Statement, error) {

--- a/pkg/exploit/wind3x_n45g.go
+++ b/pkg/exploit/wind3x_n45g.go
@@ -39,6 +39,10 @@ func (_ *epNano45G) NANDReadPage(bank, page, offset uint32) ([]uasm.Statement, u
 	panic("unimplemented")
 }
 
+func (_ *epNano45G) NANDIdentify() ([]uasm.Statement, uint32) {
+	panic("unimplemented")
+}
+
 func (_ *epNano45G) NORInit(spino uint32) ([]uasm.Statement, error) {
 	return nil, fmt.Errorf("unimplemented")
 }


### PR DESCRIPTION
Adds the NANDIdentify method for reading the JEDEC manufacturer and device ID from a target (called bank in Whimory).

It seems like the wait loops checking FMCSTAT are a bit flakey causing a timeout. I've seen a timeout value in the Samsung YP3 and Nano 3G implementations. I'll add them shortly, but feel free to review the code already :)